### PR TITLE
ignore .rbx/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.rbx
 
 db/*.db
 


### PR DESCRIPTION
I like trying to ensure apps can run on Rubinius and JRuby. This will ignore the .rbx/ directory created by Rubinius.
