### PR TITLE
Fixes issue #38 - verify setup process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,3 @@
 7. Tests the changes bundle exec rake
 8. Submit a Pull Request on github (We would like to review the code)
 9. Keep being AWESOME!
-
-## Note
-
-When running your local server, you'll want to ensure you use "foreman start"
-to ensure you're running with the `.env` configuration.

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -5,18 +5,13 @@ setup_task :setup do
 
   section "Environment Variables" do
     cfg = File.join(Rails.root, "config", "config.yml")
-
-    find_or_create_file(cfg, "Environment Variables config", true)
-
+    find_or_create_file(cfg, "Environment Variables config", false)
     done "config.yml"
   end
 
   section "Configuration Files" do
-
     database = File.join(Rails.root, 'config', 'database.yml')
-
-    find_or_create_file(database, "Database config", true)
-
+    find_or_create_file(database, "Database config", false)
     done "database.yml"
 
     # If any other configuration files are required, they should be added here
@@ -48,7 +43,11 @@ setup_task :setup do
   puts # Empty Line
 
   if console.agree("Would you like to run the test suite? (y/n)")
+    # ensure test db gets migrated as well
+    Rake::Task["db:schema:load"].reenable
+
     Rake::Task["spec"].invoke
+    Rake::Task["cucumber"].invoke
   end
 
 end


### PR DESCRIPTION
This fixes issue #38.

`rake setup` will now work in one shot, on the first try from a fresh repo. 

I had to reenable the db tasks before running the tests because the migration task wasn't running in the `#invoke` because it had already run against the development env. 
