### PR TITLE
Small edit for donors table

### DIFF
--- a/app/views/donors/index.html.haml
+++ b/app/views/donors/index.html.haml
@@ -7,13 +7,11 @@
         %tr
           %th ID
           %th Donor
-          %th Weight
           %th Actions
       %tbody
       - donors.each do |donor|
         %td= link_to donor.id, donor_path(donor)
         %td= donor.name
-        %td
         %td
           = link_to 'Edit', edit_donor_path(donor), class: 'btn btn-mini'
           = link_to 'Destroy', donor, confirm: 'Are you sure?', method: :delete, class: 'btn btn-mini btn-danger'


### PR DESCRIPTION
When I tried to add a donor entry, the actions were aligned under the "weight" column.  I changed this, but then realized that weight isn't an attribute of donor, rather of donation.  So I took out the column.  
